### PR TITLE
Added in some basic tests.

### DIFF
--- a/factor-tests/Functions_tests.swift
+++ b/factor-tests/Functions_tests.swift
@@ -1,0 +1,49 @@
+//
+//  factor_tests.swift
+//  factor-tests
+//
+//  Created by Josh Wisenbaker on 6/1/19.
+//  Copyright © 2019 ToplessBanana. All rights reserved.
+//
+
+import XCTest
+@testable import factor
+
+class Functions_tests: XCTestCase {
+
+    let goodSUTInput = ["1", "2", "10"]
+    let badSUTInput = ["3", "banana", "10"]
+    let underflowSUTInput = ["3", "10"]
+
+    func testShowFactors() {
+        showFactors(of: goodSUTInput)
+    }
+
+    func testShowFactorsBadInput() {
+        showFactors(of: badSUTInput)
+    }
+
+    func testShowGreatestCommonDivisor() {
+        showGreatestCommonDivisor(of: goodSUTInput)
+    }
+
+    func testShowGreatestCommonDivisorUnderflow() {
+        showGreatestCommonDivisor(of: underflowSUTInput)
+    }
+
+    func testShowGreatestCommonDivisorBadInput() {
+        showGreatestCommonDivisor(of: badSUTInput)
+    }
+
+    func testShowLeastCommonMultiple() {
+        showLeastCommonMultiple(of: goodSUTInput)
+    }
+
+    func testShowLeastCommonMultipleUnderflow() {
+        showLeastCommonMultiple(of: underflowSUTInput)
+    }
+
+    func testShowLeastCommonMultipleBadInput() {
+        showLeastCommonMultiple(of: badSUTInput)
+    }
+}

--- a/factor-tests/Info.plist
+++ b/factor-tests/Info.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>BNDL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+</dict>
+</plist>

--- a/factor-tests/OutputListener.swift
+++ b/factor-tests/OutputListener.swift
@@ -1,0 +1,83 @@
+//
+//  OutputListener.swift
+//  OIDCAuthTests
+//
+//  Created by Josh Wisenbaker on 1/31/19.
+//  Copyright © 2019 Jamf. All rights reserved.
+//
+
+import Foundation
+
+/// Test helper for monitoring strings written to stdout. Modified from:
+/// https://medium.com/@thesaadismail/eavesdropping-on-swifts-print-statements-57f0215efb42
+class OutputListener {
+    /// consumes the messages on STDOUT
+    let inputPipe = Pipe()
+
+    /// outputs messages back to STDOUT
+    let outputPipe = Pipe()
+
+    /// Buffers strings written to stdout
+    var contents = ""
+
+    init() {
+        // Set up a read handler which fires when data is written to our inputPipe
+        inputPipe.fileHandleForReading.readabilityHandler = { [weak self] fileHandle in
+            guard let strongSelf = self else { return }
+
+            let data = fileHandle.availableData
+            if let string = String(data: data, encoding: String.Encoding.utf8) {
+                strongSelf.contents += string
+            }
+            // Write input back to stdout
+            strongSelf.outputPipe.fileHandleForWriting.write(data)
+        }
+    }
+}
+
+extension OutputListener {
+    /// Sets up the "tee" of piped output, intercepting stdout then passing it through.
+    ///
+    /// ## [dup2 documentation](https://linux.die.net/man/2/dup2)
+    /// `int dup2(int oldfd, int newfd);`
+    /// `dup2()` makes `newfd` be the copy of `oldfd`, closing `newfd` first if necessary.
+    func openConsolePipe() {
+        var dupStatus: Int32
+
+        // Copy STDOUT file descriptor to outputPipe for writing strings back to STDOUT
+        dupStatus = dup2(stdoutFileDescriptor, outputPipe.fileHandleForWriting.fileDescriptor)
+        // Status should equal newfd
+        assert(dupStatus == outputPipe.fileHandleForWriting.fileDescriptor)
+
+        // Intercept STDOUT with inputPipe
+        // newFileDescriptor is the pipe's file descriptor and the old file descriptor is STDOUT_FILENO
+        dupStatus = dup2(inputPipe.fileHandleForWriting.fileDescriptor, stdoutFileDescriptor)
+        // Status should equal newfd
+        assert(dupStatus == stdoutFileDescriptor)
+
+        // Don't have any tests on stderr yet
+        // dup2(inputPipe.fileHandleForWriting.fileDescriptor, stderr)
+    }
+
+    /// Tears down the "tee" of piped output.
+    func closeConsolePipe() {
+        // Restore stdout
+        freopen("/dev/stdout", "a", stdout)
+
+        [inputPipe.fileHandleForReading, outputPipe.fileHandleForWriting].forEach { file in
+            file.closeFile()
+        }
+    }
+}
+
+extension OutputListener {
+    /// File descriptor for stdout (aka STDOUT_FILENO)
+    var stdoutFileDescriptor: Int32 {
+        return FileHandle.standardOutput.fileDescriptor
+    }
+
+    /// File descriptor for stderr (aka STDERR_FILENO)
+    var stderrFileDescriptor: Int32 {
+        return FileHandle.standardError.fileDescriptor
+    }
+}

--- a/factor.xcodeproj/project.pbxproj
+++ b/factor.xcodeproj/project.pbxproj
@@ -7,11 +7,27 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		0120F9E722A34DED0056BF9A /* Functions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95983A70228F4DBB00D145F9 /* Functions.swift */; };
+		0120F9E822A34E1E0056BF9A /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95325762228F47D400D51310 /* main.swift */; };
+		0120F9EA22A34E210056BF9A /* Math.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95152F81228FB79E00D41026 /* Math.swift */; };
+		0120F9EB22A34E240056BF9A /* Message.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95152F7F228FB6D900D41026 /* Message.swift */; };
+		0120F9ED22A352DF0056BF9A /* OutputListener.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0120F9EC22A352DF0056BF9A /* OutputListener.swift */; };
+		0158972E22A349C5002B0B01 /* Functions_tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0158972D22A349C5002B0B01 /* Functions_tests.swift */; };
 		95152F80228FB6D900D41026 /* Message.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95152F7F228FB6D900D41026 /* Message.swift */; };
 		95152F82228FB79E00D41026 /* Math.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95152F81228FB79E00D41026 /* Math.swift */; };
 		95325763228F47D400D51310 /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95325762228F47D400D51310 /* main.swift */; };
 		95983A71228F4DBB00D145F9 /* Functions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95983A70228F4DBB00D145F9 /* Functions.swift */; };
 /* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		0158973322A34A1B002B0B01 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 95325757228F47D400D51310 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 9532575E228F47D400D51310;
+			remoteInfo = factor;
+		};
+/* End PBXContainerItemProxy section */
 
 /* Begin PBXCopyFilesBuildPhase section */
 		9532575D228F47D400D51310 /* CopyFiles */ = {
@@ -26,6 +42,10 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		0120F9EC22A352DF0056BF9A /* OutputListener.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OutputListener.swift; sourceTree = "<group>"; };
+		0158972B22A349C5002B0B01 /* factor-tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "factor-tests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
+		0158972D22A349C5002B0B01 /* Functions_tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Functions_tests.swift; sourceTree = "<group>"; };
+		0158972F22A349C5002B0B01 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		95152F7F228FB6D900D41026 /* Message.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Message.swift; sourceTree = "<group>"; };
 		95152F81228FB79E00D41026 /* Math.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Math.swift; sourceTree = "<group>"; };
 		9532575F228F47D400D51310 /* factor */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = factor; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -36,6 +56,13 @@
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
+		0158972822A349C5002B0B01 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		9532575C228F47D400D51310 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -46,12 +73,23 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		0158972C22A349C5002B0B01 /* factor-tests */ = {
+			isa = PBXGroup;
+			children = (
+				0158972D22A349C5002B0B01 /* Functions_tests.swift */,
+				0120F9EC22A352DF0056BF9A /* OutputListener.swift */,
+				0158972F22A349C5002B0B01 /* Info.plist */,
+			);
+			path = "factor-tests";
+			sourceTree = "<group>";
+		};
 		95325756228F47D400D51310 = {
 			isa = PBXGroup;
 			children = (
 				9594478C228F48A0003779BD /* LICENSE */,
 				9594478B228F48A0003779BD /* README.md */,
 				95325761228F47D400D51310 /* factor */,
+				0158972C22A349C5002B0B01 /* factor-tests */,
 				95325760228F47D400D51310 /* Products */,
 			);
 			sourceTree = "<group>";
@@ -60,6 +98,7 @@
 			isa = PBXGroup;
 			children = (
 				9532575F228F47D400D51310 /* factor */,
+				0158972B22A349C5002B0B01 /* factor-tests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -78,6 +117,24 @@
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
+		0158972A22A349C5002B0B01 /* factor-tests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 0158973022A349C5002B0B01 /* Build configuration list for PBXNativeTarget "factor-tests" */;
+			buildPhases = (
+				0158972722A349C5002B0B01 /* Sources */,
+				0158972822A349C5002B0B01 /* Frameworks */,
+				0158972922A349C5002B0B01 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				0158973422A34A1B002B0B01 /* PBXTargetDependency */,
+			);
+			name = "factor-tests";
+			productName = "factor-tests";
+			productReference = 0158972B22A349C5002B0B01 /* factor-tests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
 		9532575E228F47D400D51310 /* factor */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = 95325766228F47D400D51310 /* Build configuration list for PBXNativeTarget "factor" */;
@@ -105,6 +162,9 @@
 				LastUpgradeCheck = 1020;
 				ORGANIZATIONNAME = ToplessBanana;
 				TargetAttributes = {
+					0158972A22A349C5002B0B01 = {
+						CreatedOnToolsVersion = 10.2.1;
+					};
 					9532575E228F47D400D51310 = {
 						CreatedOnToolsVersion = 10.2.1;
 					};
@@ -123,11 +183,35 @@
 			projectRoot = "";
 			targets = (
 				9532575E228F47D400D51310 /* factor */,
+				0158972A22A349C5002B0B01 /* factor-tests */,
 			);
 		};
 /* End PBXProject section */
 
+/* Begin PBXResourcesBuildPhase section */
+		0158972922A349C5002B0B01 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
 /* Begin PBXSourcesBuildPhase section */
+		0158972722A349C5002B0B01 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				0120F9ED22A352DF0056BF9A /* OutputListener.swift in Sources */,
+				0158972E22A349C5002B0B01 /* Functions_tests.swift in Sources */,
+				0120F9E722A34DED0056BF9A /* Functions.swift in Sources */,
+				0120F9EB22A34E240056BF9A /* Message.swift in Sources */,
+				0120F9E822A34E1E0056BF9A /* main.swift in Sources */,
+				0120F9EA22A34E210056BF9A /* Math.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		9532575B228F47D400D51310 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -141,7 +225,51 @@
 		};
 /* End PBXSourcesBuildPhase section */
 
+/* Begin PBXTargetDependency section */
+		0158973422A34A1B002B0B01 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 9532575E228F47D400D51310 /* factor */;
+			targetProxy = 0158973322A34A1B002B0B01 /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
+
 /* Begin XCBuildConfiguration section */
+		0158973122A349C5002B0B01 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				COMBINE_HIDPI_IMAGES = YES;
+				DEVELOPMENT_TEAM = WPM3555LTQ;
+				INFOPLIST_FILE = "factor-tests/Info.plist";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+					"@loader_path/../Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = "ToplessBanana.factor-tests";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 5.0;
+			};
+			name = Debug;
+		};
+		0158973222A349C5002B0B01 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				COMBINE_HIDPI_IMAGES = YES;
+				DEVELOPMENT_TEAM = WPM3555LTQ;
+				INFOPLIST_FILE = "factor-tests/Info.plist";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+					"@loader_path/../Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = "ToplessBanana.factor-tests";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 5.0;
+			};
+			name = Release;
+		};
 		95325764228F47D400D51310 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -262,9 +390,12 @@
 		95325767228F47D400D51310 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				CODE_SIGN_IDENTITY = "Mac Developer";
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = Z375TYY86Z;
+				DEFINES_MODULE = YES;
+				DEVELOPMENT_TEAM = WPM3555LTQ;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_VERSION = 5.0;
 			};
 			name = Debug;
@@ -272,9 +403,12 @@
 		95325768228F47D400D51310 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				CODE_SIGN_IDENTITY = "Mac Developer";
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = Z375TYY86Z;
+				DEFINES_MODULE = YES;
+				DEVELOPMENT_TEAM = WPM3555LTQ;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_VERSION = 5.0;
 			};
 			name = Release;
@@ -282,6 +416,15 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
+		0158973022A349C5002B0B01 /* Build configuration list for PBXNativeTarget "factor-tests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				0158973122A349C5002B0B01 /* Debug */,
+				0158973222A349C5002B0B01 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
 		9532575A228F47D400D51310 /* Build configuration list for PBXProject "factor" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (

--- a/factor.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/factor.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -2,12 +2,6 @@
 <Workspace
    version = "1.0">
    <FileRef
-      location = "group:LICENSE">
-   </FileRef>
-   <FileRef
-      location = "group:README.md">
-   </FileRef>
-   <FileRef
       location = "self:factor.xcodeproj">
    </FileRef>
 </Workspace>


### PR DESCRIPTION
It's a bit tricky to test functions that print to STDOUT, but I've included a listener class if you want to experiment with it. When testing code that has expected output or return values you would use `XCTAssert` methods in order to test for success and failure conditions.

Note with the basic tests here we are only testing the `Functions` file, but that gives us coverage of the `Math` file as well. Generally you are only going to test your public APIs. You can use code coverage values to see that all of the expected code is actually being run.


<img width="547" alt="Screen Shot 2019-06-01 at 8 59 51 PM" src="https://user-images.githubusercontent.com/560634/58755348-4350f380-84b0-11e9-9c2b-bef846b3519c.png">